### PR TITLE
Improve escaping for accordion title

### DIFF
--- a/widgets/views/widget-accordion.php
+++ b/widgets/views/widget-accordion.php
@@ -2,7 +2,7 @@
 	echo $args['before_widget'];
 
 	if ( ! empty( $instance['title'] ) ) {
-		echo $args['before_title'] . esc_html( $instance['preped_title'] ) . $args['after_title'];
+		echo $args['before_title'] . wp_kses_post( $instance['preped_title'] ) . $args['after_title'];
 	}
 ?>
 	<div class="accordion panel-group" id="accordion-<?php echo esc_attr( $args['widget_id'] ); ?>" role="tablist" aria-multiselectable="true">

--- a/widgets/widget-accordion.php
+++ b/widgets/widget-accordion.php
@@ -61,7 +61,7 @@ if ( ! class_exists( 'PW_Accordion' ) ) {
 				$instance['items'][ $key ]['content'] = wp_kses_post( $item['content'] );
 			}
 
-			$instance['title']          = sanitize_text_field( $new_instance['title'] );
+			$instance['title']          = wp_kses_post( $new_instance['title'] );
 			$instance['read_more_link'] = esc_url_raw( $new_instance['read_more_link'] );
 
 			// Sort items by ids, because order might have changed.

--- a/widgets/widget-accordion.php
+++ b/widgets/widget-accordion.php
@@ -57,7 +57,7 @@ if ( ! class_exists( 'PW_Accordion' ) ) {
 
 			foreach ( $new_instance['items'] as $key => $item ) {
 				$instance['items'][ $key ]['id']      = sanitize_key( $item['id'] );
-				$instance['items'][ $key ]['title']   = sanitize_text_field( $item['title'] );
+				$instance['items'][ $key ]['title']   = wp_kses_post( $item['title'] );
 				$instance['items'][ $key ]['content'] = wp_kses_post( $item['content'] );
 			}
 


### PR DESCRIPTION
It was only possible to add plain text in the accordion title before.
Now the users can also add HTML elements.

Support ticket reference:
https://proteusthemes.zendesk.com/agent/tickets/10548