### PR TITLE
Null-guard sparse widget instances

### DIFF
--- a/tests/test-sparse-widget-instances.php
+++ b/tests/test-sparse-widget-instances.php
@@ -1,0 +1,67 @@
+<?php
+
+class SparseWidgetInstancesTest extends WP_UnitTestCase {
+
+	function render_widget( $widget_class, $instance ) {
+		ob_start();
+		the_widget( $widget_class, $instance, array(
+			'before_widget' => '<div class="test-widget %s">',
+			'after_widget'  => '</div>',
+			'before_title'  => '<h2>',
+			'after_title'   => '</h2>',
+		) );
+		return ob_get_clean();
+	}
+
+	function assert_output_contains( $needle, $output, $message = '' ) {
+		$this->assertTrue( false !== strpos( $output, $needle ), $message );
+	}
+
+	function test_brochure_box_renders_empty_instance_with_defaults() {
+		$output = $this->render_widget( 'PW_Brochure_Box', array() );
+
+		$this->assert_output_contains( 'class="brochure-box"', $output, 'Brochure Box should render its link with an empty instance.' );
+		$this->assert_output_contains( 'href=""', $output, 'Brochure Box should default the brochure URL.' );
+		$this->assert_output_contains( 'target="_self"', $output, 'Brochure Box should default to opening in the same tab.' );
+		$this->assert_output_contains( 'class="fa  "', $output, 'Brochure Box should default the icon class.' );
+	}
+
+	function test_facebook_renders_empty_instance_with_defaults() {
+		$output = $this->render_widget( 'PW_Facebook', array() );
+
+		$this->assert_output_contains( '<h2>Facebook</h2>', $output, 'Facebook should default the title.' );
+		$this->assert_output_contains( 'href=https%3A%2F%2Fwww.facebook.com%2FProteusThemes', $output, 'Facebook should default the page URL.' );
+		$this->assert_output_contains( 'width=340', $output, 'Facebook should default the iframe width.' );
+		$this->assert_output_contains( 'height=500', $output, 'Facebook should default the iframe height.' );
+		$this->assert_output_contains( 'show_facepile=1', $output, 'Facebook should default to showing the facepile.' );
+		$this->assert_output_contains( 'min-height: 500px; width: 340px;', $output, 'Facebook should apply default dimensions.' );
+	}
+
+	function test_featured_page_ignores_empty_instance_with_defaults() {
+		unset( $GLOBALS['post'] );
+
+		$output = $this->render_widget( 'PW_Featured_Page', array() );
+
+		$this->assertSame( '', $output, 'Featured Page should return cleanly when sparse settings do not resolve to a page.' );
+	}
+
+	function test_google_map_renders_empty_instance_with_defaults() {
+		$output = $this->render_widget( 'PW_Google_Map', array() );
+
+		$this->assert_output_contains( 'data-latlng="51.507331,-0.127668"', $output, 'Google Map should default the map center.' );
+		$this->assert_output_contains( 'data-markers="[]"', $output, 'Google Map should default to an empty marker list.' );
+		$this->assert_output_contains( 'data-zoom="12"', $output, 'Google Map should default the zoom.' );
+		$this->assert_output_contains( 'data-type="roadmap"', $output, 'Google Map should default the map type.' );
+		$this->assert_output_contains( 'style="height: 380px;"', $output, 'Google Map should default the height.' );
+	}
+
+	function test_google_map_falls_back_for_invalid_locations_and_style() {
+		$output = $this->render_widget( 'PW_Google_Map', array(
+			'locations' => 'not-an-array',
+			'style'     => 'Missing Style',
+		) );
+
+		$this->assert_output_contains( 'data-markers="[]"', $output, 'Google Map should ignore non-array locations.' );
+		$this->assert_output_contains( 'data-style="[]"', $output, 'Google Map should fall back to an empty style for unknown styles.' );
+	}
+}

--- a/widgets/widget-brochure-box.php
+++ b/widgets/widget-brochure-box.php
@@ -33,6 +33,14 @@ if ( ! class_exists( 'PW_Brochure_Box' ) ) {
 		 * @param array $instance Saved values from database.
 		 */
 		public function widget( $args, $instance ) {
+			$instance = wp_parse_args( (array) $instance, array(
+				'title'         => '',
+				'brochure_url'  => '',
+				'new_tab'       => '',
+				'brochure_text' => '',
+				'brochure_icon' => '',
+			) );
+
 			// Prepare data for template
 			$instance['preped_title'] = apply_filters( 'widget_title', $instance['title'], $instance, $this->id_base );
 

--- a/widgets/widget-facebook.php
+++ b/widgets/widget-facebook.php
@@ -33,6 +33,17 @@ if ( ! class_exists( 'PW_Facebook' ) ) {
 		 * @param array $instance Saved values from database.
 		 */
 		public function widget( $args, $instance ) {
+			$instance = wp_parse_args( (array) $instance, array(
+				'title'         => 'Facebook',
+				'like_link'     => 'https://www.facebook.com/ProteusThemes',
+				'width'         => 340,
+				'height'        => 500,
+				'hide_cover'    => '',
+				'show_facepile' => '',
+				'show_posts'    => '',
+				'small_header'  => '',
+			) );
+
 			// Prepare data for template
 			$instance['preped_title'] = apply_filters( 'widget_title', $instance['title'], $instance, $this->id_base );
 

--- a/widgets/widget-featured-page.php
+++ b/widgets/widget-featured-page.php
@@ -53,6 +53,12 @@ if ( ! class_exists( 'PW_Featured_Page' ) ) {
 		 * @param array $instance
 		 */
 		public function widget( $args, $instance ) {
+			$instance = wp_parse_args( (array) $instance, array(
+				'page_id'        => 0,
+				'layout'         => 'block',
+				'read_more_text' => '',
+			) );
+
 			// Prepare data for template
 			$page_id = absint( $instance['page_id'] );
 

--- a/widgets/widget-google-map.php
+++ b/widgets/widget-google-map.php
@@ -46,9 +46,25 @@ if ( ! class_exists( 'PW_Google_Map' ) ) {
 		 * @param array $instance Saved values from database.
 		 */
 		public function widget( $args, $instance ) {
+			$instance = wp_parse_args( (array) $instance, array(
+				'latLng'    => '51.507331,-0.127668',
+				'zoom'      => 12,
+				'type'      => 'roadmap',
+				'style'     => 'Subtle Grayscale',
+				'height'    => 380,
+				'locations' => array(),
+			) );
+
+			if ( ! is_array( $instance['locations'] ) ) {
+				$instance['locations'] = array();
+			}
+
+			$map_styles = is_array( $this->map_styles ) ? $this->map_styles : array();
+			$style      = is_scalar( $instance['style'] ) ? (string) $instance['style'] : '';
+
 			// Prepare data for template
-			$instance['locations'] = json_encode( array_values( $instance['locations'] ) );
-			$instance['style']     = $this->map_styles[ $instance['style'] ];
+			$instance['locations'] = wp_json_encode( array_values( $instance['locations'] ) );
+			$instance['style']     = array_key_exists( $style, $map_styles ) ? $map_styles[ $style ] : '[]';
 
 			// widget-google-map template rendering
 			echo $this->template_engine->render_template( apply_filters( 'pw/widget_google_map_view', 'widget-google-map' ), array(

--- a/widgets/widget-google-map.php
+++ b/widgets/widget-google-map.php
@@ -64,7 +64,7 @@ if ( ! class_exists( 'PW_Google_Map' ) ) {
 
 			// Prepare data for template
 			$instance['locations'] = wp_json_encode( array_values( $instance['locations'] ) );
-			$instance['style']     = array_key_exists( $style, $map_styles ) ? $map_styles[ $style ] : '[]';
+			$instance['style']     = $map_styles[ $style ] ?? '[]';
 
 			// widget-google-map template rendering
 			echo $this->template_engine->render_template( apply_filters( 'pw/widget_google_map_view', 'widget-google-map' ), array(


### PR DESCRIPTION
## Summary
- Add render-time defaults for sparse Brochure Box, Facebook, Featured Page, and Google Map instances.
- Guard Google Map `locations` before `array_values()` and use a warning-safe map style fallback.
- Keep view partials unchanged by normalizing the `instance` payload before rendering.

## Testing
- `git diff --check`
- Not run: PHP syntax checks and PHPUnit because `php`, `composer`, `phpunit`, and the WordPress test harness are unavailable in this environment.

Closes #17

Co-Authored-By: ClauneBot <claunebot@windrushlabs.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk defensive changes that only normalize widget `$instance` data at render time and add safe fallbacks for Google Map encoding/style lookup; primary risk is minor output differences for previously malformed instances.
> 
> **Overview**
> Adds render-time normalization for several widgets by applying `wp_parse_args` defaults in `widget()` for Brochure Box, Facebook, Featured Page, and Google Map so sparse/partial `$instance` arrays no longer trigger undefined index notices.
> 
> Hardens Google Map rendering by ensuring `locations` is always an array before `array_values()`, switching to `wp_json_encode`, and providing a warning-safe style lookup with a `'[]'` fallback when the requested style key is missing or invalid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d9f25e507b79f346de80bcde87e8db2cfe2b48b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->