### PR TITLE
Guard missing attachment image srcs

### DIFF
--- a/inc/class-pw-functions.php
+++ b/inc/class-pw-functions.php
@@ -140,7 +140,11 @@ if ( ! class_exists( 'PW_Functions' ) ) {
 
 			foreach ( $sizes as $size ) {
 				$img = wp_get_attachment_image_src( $img_id, $size );
-				$srcset[] = sprintf( '%s %sw', $img[0], $img[1] ); //
+				if ( ! is_array( $img ) || ! isset( $img[0], $img[1] ) ) {
+					continue;
+				}
+
+				$srcset[] = sprintf( '%s %sw', $img[0], $img[1] );
 			}
 
 			return implode( ', ' , $srcset );

--- a/tests/test-PWFunctions.php
+++ b/tests/test-PWFunctions.php
@@ -15,6 +15,7 @@ class PWFunctionsTest extends WP_UnitTestCase {
 	function test_all_methods_exist_and_are_callable() {
 		$methods = array(
 			'get_social_icons_links',
+			'get_attachment_image_srcs',
 		);
 
 		foreach ( $methods as $method ) {
@@ -63,5 +64,45 @@ class PWFunctionsTest extends WP_UnitTestCase {
 			PW_Functions::get_social_icons_links( $array_to_test, 'foo' ),
 			'now the foo can be included'
 		);
+	}
+
+	function test_get_attachment_image_srcs_skips_missing_images() {
+		$this->assertSame(
+			'',
+			PW_Functions::get_attachment_image_srcs( 0, array( 'thumbnail', 'full' ) )
+		);
+	}
+
+	function test_get_attachment_image_srcs_skips_malformed_image_data() {
+		$filter = function( $out, $id, $size ) {
+			if ( 123 !== $id ) {
+				return $out;
+			}
+
+			if ( 'thumbnail' === $size ) {
+				return array( 'https://example.com/thumb.jpg' );
+			}
+
+			if ( 'medium' === $size ) {
+				return 'not-an-array';
+			}
+
+			if ( 'full' === $size ) {
+				return array( 'https://example.com/full.jpg', 1200, 800, false );
+			}
+
+			return $out;
+		};
+
+		add_filter( 'image_downsize', $filter, 10, 3 );
+
+		try {
+			$this->assertSame(
+				'https://example.com/full.jpg 1200w',
+				PW_Functions::get_attachment_image_srcs( 123, array( 'thumbnail', 'medium', 'full' ) )
+			);
+		} finally {
+			remove_filter( 'image_downsize', $filter, 10 );
+		}
 	}
 }


### PR DESCRIPTION
Closes #20

## Summary
- Guard `get_attachment_image_srcs()` against false, non-array, or incomplete image data.
- Add focused unit coverage for missing and malformed image data while preserving valid srcset entries.

## Verification
- `git diff --check`
- Not run: PHP syntax checks (`php` is not installed in this container)
- Not run: Composer validation (`composer` is not installed in this container)
- Not run: PHPUnit suite, per instructions

Co-Authored-By: ClauneBot <claunebot@windrushlabs.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, backward-compatible hardening that only changes behavior when WordPress returns missing/malformed attachment data, plus targeted unit tests.
> 
> **Overview**
> Hardens `PW_Functions::get_attachment_image_srcs()` to **skip** sizes where `wp_get_attachment_image_src()` returns `false`, a non-array, or an array missing expected indices, preventing bad `srcset` output.
> 
> Adds PHPUnit coverage ensuring missing attachments return an empty string and malformed size data is ignored while still emitting valid `srcset` entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a706eac74c9bacccdc5f84fb84e8a3af54f96f80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->